### PR TITLE
Cronjob-Generation only runs if cron.yaml exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# docker-cron
+
+This is a docker image based on (jcgruenhage/baseimage-alpine)[https://github.com/jcgruenhage/docker-baseimage-alpine]
+with (alpine-cron-schedular)[https://git.jcg.re/jcgruenhage/alpine-cron-scheduler] installed.
+
+## Cronjob auto-generation
+
+The container will automatically try to generate cron-jobs from `/config/cron.yaml` (for an example of the syntax
+see (exampleConfig/cron.yaml)[exampleConfig/cron.yaml]. If the file cannot be found, the generation is skipped.

--- a/root/etc/s6.d/cronGen/run
+++ b/root/etc/s6.d/cronGen/run
@@ -1,4 +1,11 @@
 #!/bin/sh
 s6-svc -O /etc/s6.d/cronGen
-echo "Regenerating cronjobs based on config file."
-exec alpine-cron-scheduler /config/cron.yaml
+
+CONFIGFILE="/config/cron.yaml"
+
+if [[ -e "$CONFIGFILE" ]]; then
+	echo "INFO Regenerating cronjobs based on config file."
+	exec alpine-cron-scheduler ${CONFIGFILE}
+elif [[ ! -e "$CONFIGFILE" ]]; then
+	echo "INFO $CONFIGFILE not found, skipping generation of cron jobs from configuration file"
+fi;


### PR DESCRIPTION
- Made cronjob generation depend on existance of the generation-sourcefile `/config/cron.yaml`
- Documented the behaviour of the container when the cron.yaml file is missing